### PR TITLE
hash assignments for testing with pangolin handle_cache branch

### DIFF
--- a/pango_assignment.cache.csv.gz
+++ b/pango_assignment.cache.csv.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1a5c39eaa58b350bcdb0ca0d0cac581b39b035f55c8169f724d85fdd1bc3a9f5
+size 143563664

--- a/pango_usher.csv.gz
+++ b/pango_usher.csv.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1a5c39eaa58b350bcdb0ca0d0cac581b39b035f55c8169f724d85fdd1bc3a9f5
+size 143563664


### PR DESCRIPTION
pango_assignment.cache.csv.gz contains full CSV output indexed by aligned & masked sequence hash, stored by git LFS.  Intended to work with current handle_cache branch of pangolin.