### PR TITLE
Adding assignments for hashes unique to COG-UK & GenBank (downloaded 2022-01-20)

### DIFF
--- a/pangolin_assignment/pango_assignment.cache.csv.gz
+++ b/pangolin_assignment/pango_assignment.cache.csv.gz
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1a5c39eaa58b350bcdb0ca0d0cac581b39b035f55c8169f724d85fdd1bc3a9f5
-size 143563664
+oid sha256:f30df1f35002a8202cf14a844e3ab806c56c28cb21c9420142a28fc29b50ec15
+size 122564273


### PR DESCRIPTION
I added ~250k unique to COG-UK and ~100k unique to GenBank.  

When combining all together, I sorted by the second column (lineage; used `sort -t, -k2`) so that there would be more local similarity in the uncompressed CSV, hoping that would help compression, and indeed the compressed file size reduced from the previous commit's 143563664 to 122564273 (~17% smaller despite having ~6% more lines).

When trimming to only the first two fields (hash and lineage), sorting by hash (just `sort`) and compressing, the final size was 116426490, but sorting by lineage (`sort -t, -k2`) and compressing reduced the size further to 112018843, still not all that much smaller than the lineage-sorted full results.  Looks like it'll be git-lfs either way.  (I guess we could use truncated md5sums instead of the full 128-bit / 32-hex-char strings, with an increased risk of hash collisions, but we probably all have more urgent things to do than figure out how far we could push that.)