### PR TITLE
Release for testing

### DIFF
--- a/pangolin_assignment/__init__.py
+++ b/pangolin_assignment/__init__.py
@@ -1,3 +1,3 @@
 _program = "pangolin-assignment"
-__version__ = "v1.2.12.."
-__date__ = "2022-01-19"
+__version__ = "v1.2.127"
+__date__ = "2022-03-09"

--- a/pangolin_assignment/usher_assignments.cache.csv.gz
+++ b/pangolin_assignment/usher_assignments.cache.csv.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:537f50cfd18806addb84f4bd351df312c9c55de2b736a7a10d782530086b316e
+size 187379714


### PR DESCRIPTION
In order to test some changes to pangolin branch handle_cache that will update how the cache file is installed, updated and used, I need pangolin-assignment to have a release that is in sync with pangolin-data.  This PR adds a new file usher_assignments.cache.csv.gz and sets __version__ to v1.2.127 .  usher_assignments.cache.csv.gz has pangolin v4.0 output columns, although it is currently derived from the output of pangolin 3.1.20 so its qc_notes column is empty.