### PR TITLE
Updated pangolin v4.0 cache file for testing (reduced column set, new sequences).

### DIFF
--- a/pangolin_assignment/__init__.py
+++ b/pangolin_assignment/__init__.py
@@ -1,3 +1,3 @@
 _program = "pangolin-assignment"
 __version__ = "v1.2.127"
-__date__ = "2022-03-10"
+__date__ = "2022-03-16"

--- a/pangolin_assignment/usher_assignments.cache.csv.gz
+++ b/pangolin_assignment/usher_assignments.cache.csv.gz
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:0ba5dd6dff9c736a0205d6061502e81f0c8c008b6dab52a2bb6b9252a6473059
-size 193191540
+oid sha256:30e80f588a675a19da84da8e36cdcaeb3b9d4e93df9e371f05737af06da571ff
+size 160141388


### PR DESCRIPTION
Assignment cache from pango-designation v1.2.127 on GISAID sequences downloaded through 2022-03-16.
Using Rachel's new --skip-scorpio flag and restricting columns so scorpio from runtime is used.