### PR TITLE
Prerelease v1.11

### DIFF
--- a/pangolin_assignment/__init__.py
+++ b/pangolin_assignment/__init__.py
@@ -1,3 +1,3 @@
 _program = "pangolin-assignment"
-__version__ = "1.9"
-__date__ = "2022-05-22"
+__version__ = "1.11"
+__date__ = "2022-06-22"

--- a/pangolin_assignment/usher_assignments.cache.csv.gz
+++ b/pangolin_assignment/usher_assignments.cache.csv.gz
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:44fddc21b2978baa5ba335e850d30fb78013264c1ca29165e56779e1e7df0c1b
-size 192040269
+oid sha256:3b17421d4fb23f6ae4a97cd58d389ec0c7f56aeb6df15e78e2dc39ac54645cdd
+size 200750167


### PR DESCRIPTION
Move changes from prerelease branch to master.
Assignment cache from pango-designation v1.11 on GISAID sequences downloaded through 2022-06-22

The cache was computed at UCSC on sequences downloaded from [GISAID](https://gisaid.org/) using the following software versions:

pangolin: 4.0.6 (with --skip-scorpio flag and --usher-tree <[v1.9 lineageTree.pb](https://github.com/cov-lineages/pangolin-data/blob/v1.9/pangolin_data/data/lineageTree.pb)> file prior to v1.9 release)
usher: v0.5.4
faToVcf: bioconda 426
gofasta: bioconda 1.0.0
minimap2: bioconda 2.24 (--version --> 2.24-r1122)