### PR TITLE
Prerelease v1.12 branch

### DIFF
--- a/pangolin_assignment/__init__.py
+++ b/pangolin_assignment/__init__.py
@@ -1,3 +1,3 @@
 _program = "pangolin-assignment"
-__version__ = "1.11"
-__date__ = "2022-06-22"
+__version__ = "1.12"
+__date__ = "2022-07-11"

--- a/pangolin_assignment/usher_assignments.cache.csv.gz
+++ b/pangolin_assignment/usher_assignments.cache.csv.gz
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:3b17421d4fb23f6ae4a97cd58d389ec0c7f56aeb6df15e78e2dc39ac54645cdd
-size 200750167
+oid sha256:a05df73d21348b2180047edffda7ca0bf7f8f518370f0ae3865d6c40897f5996
+size 206332730


### PR DESCRIPTION
Assignment cache from pango-designation v1.12 on GISAID sequences downloaded through 2022-07-11

The cache was computed at UCSC on sequences downloaded from [GISAID](https://gisaid.org/) using the following software versions:

pangolin: 4.1.1 (with --skip-scorpio flag and --usher-tree <[v1.12 lineageTree.pb](https://github.com/cov-lineages/pangolin-data/blob/v1.12/pangolin_data/data/lineageTree.pb)> file prior to v1.12 release)
usher: v0.5.4
faToVcf: bioconda 426
gofasta: bioconda 1.0.0
minimap2: bioconda 2.24 (--version --> 2.24-r1122)