### PR TITLE
Prerelease v1.14 branch

### DIFF
--- a/pangolin_assignment/__init__.py
+++ b/pangolin_assignment/__init__.py
@@ -1,3 +1,3 @@
 _program = "pangolin-assignment"
-__version__ = "1.13"
-__date__ = "2022-08-01"
+__version__ = "1.14"
+__date__ = "2022-08-21"

--- a/pangolin_assignment/usher_assignments.cache.csv.gz
+++ b/pangolin_assignment/usher_assignments.cache.csv.gz
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b2b01f7992d2c5f2b2b780cd3d64e6d64a8c718aeb328283a0a7c163b03a06ab
-size 214914744
+oid sha256:21dcece08147ecb81a87ad593b3ddc6349677a70f63c055b1ed85fcc65d46ab4
+size 222170880


### PR DESCRIPTION
Assignment cache from pango-designation v1.14 on GISAID sequences downloaded through 2022-08-21

The cache was computed at UCSC on sequences downloaded from [GISAID](https://gisaid.org/), using pangolin with the `--skip-scorpio` flag and `--usher-tree` <[v1.14 lineageTree.pb](https://github.com/cov-lineages/pangolin-data/blob/v1.14/pangolin_data/data/lineageTree.pb)> file prior to v1.14 release
```
pangolin: 4.1.2
usher 0.5.4
gofasta 1.0.0
minimap2 2.24-r1122
faToVcf: 426
```

