### PR TITLE
Prerelease v1.18.1

### DIFF
--- a/pangolin_assignment/__init__.py
+++ b/pangolin_assignment/__init__.py
@@ -1,3 +1,3 @@
 _program = "pangolin-assignment"
-__version__ = "1.18"
-__date__ = "2023-01-11"
+__version__ = "1.18.1"
+__date__ = "2023-02-16"

--- a/pangolin_assignment/usher_assignments.cache.csv.gz
+++ b/pangolin_assignment/usher_assignments.cache.csv.gz
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ccf0f1500c9ca2d368d33afe6d9132f0950eeb7e8bbbbf59929d66dd2d296aa4
-size 250112623
+oid sha256:6fe3b7c9c03d05a802deb25d857efb77f4a62c1591c2a089577f27c6fd507f4f
+size 258973117


### PR DESCRIPTION
Assignment cache from pango-designation v1.18.1 on GISAID sequences downloaded through 2023-02-16

The cache was computed at UCSC on sequences downloaded from [GISAID](https://gisaid.org/), using pangolin with the `--skip-scorpio` flag and `--usher-tree` <[v1.18.1 lineageTree.pb](https://github.com/cov-lineages/pangolin-data/blob/v1.18.1/pangolin_data/data/lineageTree.pb)> file prior to v1.18.1 release.
```
pangolin: 4.2
usher 0.6.2
gofasta 1.1.0
minimap2 2.24-r1122
faToVcf: 426
```
