### PR TITLE
minor version bump v1.18.1.1 to stay in sync with pangolin-data

### DIFF
--- a/pangolin_assignment/__init__.py
+++ b/pangolin_assignment/__init__.py
@@ -1,3 +1,3 @@
 _program = "pangolin-assignment"
-__version__ = "1.18.1"
+__version__ = "1.18.1.1"
 __date__ = "2023-02-16"


### PR DESCRIPTION
pangolin-data required a little [update](https://github.com/cov-lineages/pangolin-data/pull/36) to v1.18.1.1; no change required here beyond keeping the latest release versions consistent.