### PR TITLE
Prerelease v1.21

### DIFF
--- a/pangolin_assignment/__init__.py
+++ b/pangolin_assignment/__init__.py
@@ -1,3 +1,3 @@
 _program = "pangolin-assignment"
-__version__ = "1.20"
-__date__ = "2023-05-22"
+__version__ = "1.21"
+__date__ = "2023-06-21"

--- a/pangolin_assignment/usher_assignments.cache.csv.gz
+++ b/pangolin_assignment/usher_assignments.cache.csv.gz
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:886e8568ac78db0acc278b0cfb4f70e6c5b2bd4013c7e7431a7c546f6bb55ff8
-size 273031237
+oid sha256:fad07c4921c625dafa2444073fe90a9785c2924ffc36ce813b3ecf691f7820da
+size 275337166


### PR DESCRIPTION
Assignment cache from pango-designation v1.21 on GISAID sequences downloaded through 2023-06-21

The cache was computed at UCSC on sequences downloaded from [GISAID](https://gisaid.org/), using pangolin with the `--skip-scorpio` flag and `--usher-tree` <[v1.21 lineageTree.pb](https://github.com/cov-lineages/pangolin-data/blob/v1.21/pangolin_data/data/lineageTree.pb)> file prior to v1.21 release.
```
pangolin: 4.3
usher 0.6.2
gofasta 1.2.0
minimap2 2.24-r1122
faToVcf: 426
```
