### PR TITLE
Prerelease v1.22

### DIFF
--- a/pangolin_assignment/__init__.py
+++ b/pangolin_assignment/__init__.py
@@ -1,3 +1,3 @@
 _program = "pangolin-assignment"
-__version__ = "1.21"
-__date__ = "2023-06-21"
+__version__ = "1.22"
+__date__ = "2023-08-17"

--- a/pangolin_assignment/usher_assignments.cache.csv.gz
+++ b/pangolin_assignment/usher_assignments.cache.csv.gz
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:fad07c4921c625dafa2444073fe90a9785c2924ffc36ce813b3ecf691f7820da
-size 275337166
+oid sha256:a7adf3bc4bccba937ef7048355a9e96ea7118678be951748519cad84ab2236d6
+size 278498178


### PR DESCRIPTION
Assignment cache from pango-designation v1.22 on GISAID sequences downloaded through 2023-08-17

The cache was computed at UCSC on sequences downloaded from [GISAID](https://gisaid.org/), using pangolin with the `--skip-scorpio` flag and `--usher-tree` <[v1.22 lineageTree.pb](https://github.com/cov-lineages/pangolin-data/blob/v1.22/pangolin_data/data/lineageTree.pb)> file prior to v1.22 release.
```
pangolin: 4.3.1
usher 0.6.2
gofasta 1.2.0
minimap2 2.24-r1122
faToVcf: 426
```
