### PR TITLE
Prerelease v1.23

### DIFF
--- a/pangolin_assignment/__init__.py
+++ b/pangolin_assignment/__init__.py
@@ -1,3 +1,3 @@
 _program = "pangolin-assignment"
-__version__ = "1.22"
-__date__ = "2023-08-17"
+__version__ = "1.23"
+__date__ = "2023-10-16"

--- a/pangolin_assignment/usher_assignments.cache.csv.gz
+++ b/pangolin_assignment/usher_assignments.cache.csv.gz
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a7adf3bc4bccba937ef7048355a9e96ea7118678be951748519cad84ab2236d6
-size 278498178
+oid sha256:24d49a6b1e478125e98fe3c80909d269f1177dc7b034d2d98db7803c4c0baa79
+size 283543014


### PR DESCRIPTION
Assignment cache from pango-designation v1.23 on GISAID sequences downloaded through 2023-10-16

The cache was computed at UCSC on sequences downloaded from [GISAID](https://gisaid.org/), using pangolin with the `--skip-scorpio` flag and `--usher-tree` <[v1.23 lineageTree.pb](https://github.com/cov-lineages/pangolin-data/blob/v1.23/pangolin_data/data/lineageTree.pb)> file prior to v1.23 release.

*** NOTE: for v1.23 only, a modified version of usher was used; this modified version is expected to become usher version 0.6.3.  It has a bugfix for a corner case that affects only samples whose best placement is at the root node, which for pangolin is lineage A, and the v1.23 tree triggers the bug in more cases than the previous trees which is why the bug was not discovered until this release.

If you will be running pangolin on early 2020 sequences that may be lineage A, it is highly recommended to use the assignment cache and to update usher to 0.6.3 as soon as it is released.

```
pangolin: 4.3.1
usher 0.6.3 (not yet released)
gofasta 1.2.0
minimap2 2.24-r1122
faToVcf: 426
```