### PR TITLE
Minor release v1.23.1 to stay in sync with pangolin-data

### DIFF
--- a/pangolin_assignment/__init__.py
+++ b/pangolin_assignment/__init__.py
@@ -1,3 +1,3 @@
 _program = "pangolin-assignment"
-__version__ = "1.23"
+__version__ = "1.23.1"
 __date__ = "2023-10-16"


### PR DESCRIPTION
pangolin-data v1.23.1 minor release adds JQ to alias_key.json, which has no effect on the cached lineage assignments; pangolin-data's alias_key.json is used only for comparison of inference lineage (from usher) with scorpio assignment.