### PR TITLE
pangolin-assignment v1.26

### DIFF
--- a/pangolin_assignment/__init__.py
+++ b/pangolin_assignment/__init__.py
@@ -1,3 +1,3 @@
 _program = "pangolin-assignment"
-__version__ = "1.25.1"
-__date__ = "2024-02-09"
+__version__ = "1.26"
+__date__ = "2024-03-08"

--- a/pangolin_assignment/usher_assignments.cache.csv.gz
+++ b/pangolin_assignment/usher_assignments.cache.csv.gz
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:314178d8d6e30d133b81e78b13858d5db32f3edcbe3ad0b1cb7818093bf5330c
-size 293672529
+oid sha256:b3bab862357d9828733d1602752e4ec32d5d93b952ab05d2a7b814fc4ffff601
+size 295764126


### PR DESCRIPTION
Assignment cache from pango-designation v1.26 on GISAID sequences downloaded through 2024-03-08

The cache was computed at UCSC on sequences downloaded from [GISAID](https://gisaid.org/), using pangolin with the `--skip-scorpio` flag and `--usher-tree` <[v1.26 lineageTree.pb](https://github.com/cov-lineages/pangolin-data/blob/v1.26/pangolin_data/data/lineageTree.pb)> file prior to v1.26 release.

```
pangolin: 4.3.1
usher 0.6.3
gofasta 1.2.1
minimap2 2.26-r1175
faToVcf: 448
```