### PR TITLE
pangolin-assignment v1.28

### DIFF
--- a/pangolin_assignment/__init__.py
+++ b/pangolin_assignment/__init__.py
@@ -1,3 +1,3 @@
 _program = "pangolin-assignment"
-__version__ = "1.27"
-__date__ = "2024-04-24"
+__version__ = "1.28"
+__date__ = "2024-06-21"

--- a/pangolin_assignment/usher_assignments.cache.csv.gz
+++ b/pangolin_assignment/usher_assignments.cache.csv.gz
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a00a744e86ece6171feac197049752d8d8b9176751d9a3de7e6d2cf1153cd86e
-size 296660601
+oid sha256:a212b40ce6f0649ab9d395117d5590fc0ce0e1fbc85f7ea0011e616a92bc1670
+size 298801217


### PR DESCRIPTION
Assignment cache from pango-designation v1.28 on GISAID sequences downloaded through 2024-06-21

The cache was computed at UCSC on sequences downloaded from [GISAID](https://gisaid.org/), using pangolin with the `--skip-scorpio` flag and `--usher-tree` <[v1.28 lineageTree.pb](https://github.com/cov-lineages/pangolin-data/blob/v1.28/pangolin_data/data/lineageTree.pb)> file prior to v1.28 release.

```
pangolin: 4.3.1
usher 0.6.3
gofasta 1.2.1
minimap2 2.26-r1175
faToVcf: 448
```