### PR TITLE
pangolin-assignment v1.28.1

### DIFF
--- a/pangolin_assignment/__init__.py
+++ b/pangolin_assignment/__init__.py
@@ -1,3 +1,3 @@
 _program = "pangolin-assignment"
-__version__ = "1.28"
-__date__ = "2024-06-21"
+__version__ = "1.28.1"
+__date__ = "2024-07-01"

--- a/pangolin_assignment/usher_assignments.cache.csv.gz
+++ b/pangolin_assignment/usher_assignments.cache.csv.gz
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a212b40ce6f0649ab9d395117d5590fc0ce0e1fbc85f7ea0011e616a92bc1670
-size 298801217
+oid sha256:b1852a387906af8ad999f0eaa5cadbea44df4a2d1ae4990c78f2763023b544d1
+size 299583497


### PR DESCRIPTION
Assignment cache from pango-designation v1.28 on GISAID sequences downloaded through 2024-07-01, rebuilt for pangolin-data and pangolin-assignment release v1.28.1 (minor release to fix accidental inclusion of KR.2, see https://github.com/cov-lineages/pangolin-data/issues/60).

The cache was computed at UCSC on sequences downloaded from [GISAID](https://gisaid.org/), using pangolin with the `--skip-scorpio` flag and `--usher-tree` <[v1.28.1 lineageTree.pb](https://github.com/cov-lineages/pangolin-data/blob/v1.28.1/pangolin_data/data/lineageTree.pb)> file prior to v1.28.1 release.

```
pangolin: 4.3.1
usher 0.6.3
gofasta 1.2.1
minimap2 2.26-r1175
faToVcf: 448
```