### PR TITLE
pangolin-assignment v1.29

### DIFF
--- a/pangolin_assignment/__init__.py
+++ b/pangolin_assignment/__init__.py
@@ -1,3 +1,3 @@
 _program = "pangolin-assignment"
-__version__ = "1.28.1"
-__date__ = "2024-07-01"
+__version__ = "1.29"
+__date__ = "2024-07-26"

--- a/pangolin_assignment/usher_assignments.cache.csv.gz
+++ b/pangolin_assignment/usher_assignments.cache.csv.gz
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b1852a387906af8ad999f0eaa5cadbea44df4a2d1ae4990c78f2763023b544d1
-size 299583497
+oid sha256:280fd662be8ca5e088f7c8a7aa321e7e675b7cf27d5dd155e091218780d5097c
+size 300750233


### PR DESCRIPTION
Assignment cache from pango-designation v1.29 on GISAID sequences downloaded through 2024-07-26

The cache was computed at UCSC on sequences downloaded from [GISAID](https://gisaid.org/), using pangolin with the `--skip-scorpio` flag and `--usher-tree` <[v1.29 lineageTree.pb](https://github.com/cov-lineages/pangolin-data/blob/v1.29/pangolin_data/data/lineageTree.pb)> file prior to v1.29 release.

```
pangolin: 4.3.1
usher 0.6.3
gofasta 1.2.1
minimap2 2.26-r1175
faToVcf: 448
```