### PR TITLE
pangolin-assignment v1.30

### DIFF
--- a/pangolin_assignment/__init__.py
+++ b/pangolin_assignment/__init__.py
@@ -1,3 +1,3 @@
 _program = "pangolin-assignment"
-__version__ = "1.29"
-__date__ = "2024-07-26"
+__version__ = "1.30"
+__date__ = "2024-09-19"

--- a/pangolin_assignment/usher_assignments.cache.csv.gz
+++ b/pangolin_assignment/usher_assignments.cache.csv.gz
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:280fd662be8ca5e088f7c8a7aa321e7e675b7cf27d5dd155e091218780d5097c
-size 300750233
+oid sha256:e6a13323f64ae6e2a18adea15a260ec85e3c1fd53a6d142052b9b243b880c207
+size 303577411


### PR DESCRIPTION
Assignment cache from pango-designation v1.30 on GISAID sequences downloaded through 2024-09-19

The cache was computed at UCSC on sequences downloaded from [GISAID](https://gisaid.org/), using pangolin with the `--skip-scorpio` flag and `--usher-tree` <[v1.30 lineageTree.pb](https://github.com/cov-lineages/pangolin-data/blob/v1.30/pangolin_data/data/lineageTree.pb)> file prior to v1.30 release.

```
pangolin: 4.3.1
usher 0.6.3
gofasta 1.2.1
minimap2 2.26-r1175
faToVcf: 448
```