### PR TITLE
pangolin-assignment v1.32

### DIFF
--- a/pangolin_assignment/__init__.py
+++ b/pangolin_assignment/__init__.py
@@ -1,3 +1,3 @@
 _program = "pangolin-assignment"
-__version__ = "1.31"
-__date__ = "2024-11-19"
+__version__ = "1.32"
+__date__ = "2025-01-23"

--- a/pangolin_assignment/usher_assignments.cache.csv.gz
+++ b/pangolin_assignment/usher_assignments.cache.csv.gz
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f66b36539638487900deb47ca998d4cb57d447ecb309db261ab7ea63a2f82ede
-size 305492916
+oid sha256:45ccd8e692eef2aea3dc47a310b4899d878b7353bf370bcb756f4f7eb2e8b1ed
+size 307137950


### PR DESCRIPTION
Assignment cache from pango-designation v1.32 on GISAID sequences downloaded through 2025-01-23

The cache was computed at UCSC on sequences downloaded from [GISAID](https://gisaid.org/), using pangolin with the `--skip-scorpio` flag and `--usher-tree` <[v1.32 lineageTree.pb](https://github.com/cov-lineages/pangolin-data/blob/v1.32/pangolin_data/data/lineageTree.pb)> file prior to v1.32 release.

```
pangolin: 4.3.1
usher 0.6.3
gofasta 1.2.1
minimap2 2.26-r1175
faToVcf: 448
```