### PR TITLE
pangolin-assignment v1.33

### DIFF
--- a/pangolin_assignment/__init__.py
+++ b/pangolin_assignment/__init__.py
@@ -1,3 +1,3 @@
 _program = "pangolin-assignment"
-__version__ = "1.32"
-__date__ = "2025-01-23"
+__version__ = "1.33"
+__date__ = "2025-03-19"

--- a/pangolin_assignment/usher_assignments.cache.csv.gz
+++ b/pangolin_assignment/usher_assignments.cache.csv.gz
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:45ccd8e692eef2aea3dc47a310b4899d878b7353bf370bcb756f4f7eb2e8b1ed
-size 307137950
+oid sha256:83d5ab2186bf476619a40bc06b13960bab778bec8ef524169dbc0ae181f155b4
+size 308250827


### PR DESCRIPTION
Assignment cache from pango-designation v1.33.1 on GISAID sequences downloaded through 2025-03-19

The cache was computed at UCSC on sequences downloaded from [GISAID](https://gisaid.org/), using pangolin with the `--skip-scorpio` flag and `--usher-tree` <[v1.33 lineageTree.pb](https://github.com/cov-lineages/pangolin-data/blob/v1.33/pangolin_data/data/lineageTree.pb)> file prior to v1.33 release.

```
pangolin: 4.3.1
usher 0.6.3
gofasta 1.2.1
minimap2 2.26-r1175
faToVcf: 448
```