### PR TITLE
pangolin-assignment v1.34

### DIFF
--- a/pangolin_assignment/__init__.py
+++ b/pangolin_assignment/__init__.py
@@ -1,3 +1,3 @@
 _program = "pangolin-assignment"
-__version__ = "1.33"
-__date__ = "2025-03-19"
+__version__ = "1.34"
+__date__ = "2025-06-11"

--- a/pangolin_assignment/usher_assignments.cache.csv.gz
+++ b/pangolin_assignment/usher_assignments.cache.csv.gz
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:83d5ab2186bf476619a40bc06b13960bab778bec8ef524169dbc0ae181f155b4
-size 308250827
+oid sha256:a0a0a0bfd25c203a1f06a6e4b583ae4ec87149fe9047417e0c31acb8bad80112
+size 310270576


### PR DESCRIPTION
Assignment cache from pango-designation  on GISAID sequences downloaded through 2025-06-11

The cache was computed at UCSC on sequences downloaded from [GISAID](https://gisaid.org/), using pangolin with the `--skip-scorpio` flag and `--usher-tree` <[v1.34 lineageTree.pb](https://github.com/cov-lineages/pangolin-data/blob/v1.34/pangolin_data/data/lineageTree.pb)> file prior to v1.34 release.

```
pangolin: 4.3.1
usher 0.6.3
gofasta 1.2.1
minimap2 2.26-r1175
faToVcf: 448
```