### PR TITLE
pangolin-assignment v1.35

### DIFF
--- a/pangolin_assignment/__init__.py
+++ b/pangolin_assignment/__init__.py
@@ -1,3 +1,3 @@
 _program = "pangolin-assignment"
-__version__ = "1.34"
-__date__ = "2025-06-11"
+__version__ = "1.35"
+__date__ = "2025-09-10"

--- a/pangolin_assignment/usher_assignments.cache.csv.gz
+++ b/pangolin_assignment/usher_assignments.cache.csv.gz
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a0a0a0bfd25c203a1f06a6e4b583ae4ec87149fe9047417e0c31acb8bad80112
-size 310270576
+oid sha256:3e454fd4d40eedd82faf3e21410259a27c57093043042c0cab15d9325079dc4c
+size 314612497


### PR DESCRIPTION
Assignment cache from pango-designation v1.35 on GISAID sequences downloaded through 2025-09-10

The cache was computed at UCSC on sequences downloaded from [GISAID](https://gisaid.org/), using pangolin with the `--skip-scorpio` flag and `--usher-tree` <[v1.35 lineageTree.pb](https://github.com/cov-lineages/pangolin-data/blob/v1.35/pangolin_data/data/lineageTree.pb)> file prior to v1.35 release.

```
pangolin: 4.3.1
usher 0.6.3
gofasta 1.2.1
minimap2 2.26-r1175
faToVcf: 448
```